### PR TITLE
add PKCE support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,12 @@ jobs:
             arch: x86
             version: 1
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -50,6 +50,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml
 /docs/build/
 /docs/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -13,13 +13,15 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JWTs = "d850fbd6-035d-5a70-a269-1ca2e636ac6c"
 MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
 julia = "1"
 HTTP = "0.8, 0.9, 1"
 JSON = "0.21"
-JWTs = "0.1,0.2"
+JWTs = "0.1, 0.2, 0.3"
 MbedTLS = "0.6.8, 0.7, 1"
+SHA = "<0.0.1, 0.7, 1"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/OpenIDConnect.jl
+++ b/src/OpenIDConnect.jl
@@ -5,6 +5,7 @@ using JSON
 using MbedTLS
 using Base64
 using Random
+using Random.SHA 
 using JWTs
 
 const DEFAULT_SCOPES = ["openid", "profile", "email"]
@@ -21,6 +22,7 @@ The context holds request states, and configuration options.
 """
 struct OIDCCtx
     states::Dict{String,Float64}
+    code_verifiers::Dict{String,String}
     state_timeout_secs::Int
     allowed_skew_secs::Int
     openid_config::Dict{String,Any}
@@ -60,7 +62,7 @@ struct OIDCCtx
         openid_config = JSON.parse(String(HTTP.request("GET", openid_config_url; status_exception=true, http_tls_opts...).body))
         validator = JWKSet(openid_config["jwks_uri"])
 
-        new(Dict{String,Float64}(), state_timeout_secs, allowed_skew_secs, openid_config, http_tls_opts, validator, key_refresh_secs, 0.0, client_id, client_secret, scopes, redirect_uri, random_device)
+        new(Dict{String,Float64}(), Dict{String,String}(), state_timeout_secs, allowed_skew_secs, openid_config, http_tls_opts, validator, key_refresh_secs, 0.0, client_id, client_secret, scopes, redirect_uri, random_device)
     end
 end
 
@@ -69,6 +71,11 @@ token_endpoint(ctx::OIDCCtx) = ctx.openid_config["token_endpoint"]
 
 function remember_state(ctx::OIDCCtx, state::String)
     ctx.states[state] = time()
+    nothing
+end
+
+function remember_verifier(ctx::OIDCCtx, state::String, code_verifier::String)
+    ctx.code_verifiers[state] = code_verifier
     nothing
 end
 
@@ -88,11 +95,27 @@ function validate_state(ctx::OIDCCtx, state::String)
     false
 end
 
-function purge_states(ctx::OIDCCtx)
+function purge_states!(ctx::OIDCCtx)
     tnow = time()
     tmout = ctx.state_timeout_secs
-    filter!(nv->(tnow-nv[2])>tmout, ctx.states)
+    nv_keys = findall(nv->(tnow-nv)>tmout, ctx.states)
+    for k in nv_keys
+        delete!(ctx.states, k)
+        delete!(ctx.code_verifiers, k)
+    end
     nothing
+end
+
+# for compatibility
+const purge_states = purge_states!
+
+function generate_code_challenge(ctx::Union{OIDCCtx,Nothing})
+    code_verifier = ctx === nothing ? randstring(128) : randstring(ctx.random_device, 128)
+    hash = sha256(code_verifier)
+    # see https://datatracker.ietf.org/doc/html/rfc7636#appendix-B
+    code_challenge = replace(rstrip(base64encode(hash), '='), '+' => '-', '/' => '_')
+
+    return code_challenge, code_verifier
 end
 
 """
@@ -119,13 +142,21 @@ Acceptable optional args as listed in section 3.1.2.1 of specifications (https:/
 Returns a String with the redirect URL.
 Caller must perform the redirection.
 """
-function flow_request_authorization_code(ctx::OIDCCtx; nonce=nothing, display=nothing, prompt=nothing, max_age=nothing, ui_locales=nothing, id_token_hint=nothing, login_hint=nothing, acr_values=nothing)
+function flow_request_authorization_code(ctx::OIDCCtx; nonce=nothing, display=nothing, prompt=nothing, max_age=nothing, ui_locales=nothing, id_token_hint=nothing, login_hint=nothing, acr_values=nothing, pkce::Bool=false)
     @debug("oidc negotiation: initiating...")
     scopes = join(ctx.scopes, ' ')
     state = randstring(ctx.random_device, 10)
     remember_state(ctx, state)
 
     query = Dict("response_type"=>"code", "client_id"=>ctx.client_id, "redirect_uri"=>ctx.redirect_uri, "scope"=>scopes, "state"=>state)
+
+    if pkce
+        code_challenge, code_verifier = generate_code_challenge(ctx)
+        remember_verifier(ctx, state, code_verifier)
+        query["code_challenge_method"] = "S256"
+        query["code_challenge"] = code_challenge
+    end
+
     (nonce          === nothing) || (query["nonce"]         = String(nonce))
     (display        === nothing) || (query["display"]       = String(display))
     (prompt         === nothing) || (query["prompt"]        = String(prompt))
@@ -157,6 +188,14 @@ function flow_get_authorization_code(ctx::OIDCCtx, @nospecialize(query))
 
     code = get(query, "code", get(query, :code, nothing))
     if code !== nothing
+        if haskey(ctx.code_verifiers, state)
+            # store the verifier under the key code, 
+            # because that's the only available information during `flow_get_token()`
+            # and store the validity of the code in states for purging purposes, even if it's not a state
+            ctx.code_verifiers[code] = ctx.code_verifiers[state]
+            delete!(ctx.code_verifiers, state)
+            remember_state(ctx, code)
+        end
         return String(code)
     end
 
@@ -199,8 +238,14 @@ function flow_get_token(ctx::OIDCCtx, code)
                 "redirect_uri"=>ctx.redirect_uri,
                 "client_id"=>ctx.client_id,
                 "client_secret"=>ctx.client_secret)
+    code_verifier = get(ctx.code_verifiers, code, "")
+    isempty(code_verifier) || push!(data, "code_verifier" => code_verifier)
     headers = Dict("Content-Type"=>"application/x-www-form-urlencoded")
     tok_res = HTTP.request("POST", token_endpoint(ctx), headers, HTTP.URIs.escapeuri(data); status_exception=false, ctx.http_tls_opts...)
+    if !isempty(code_verifier)
+        delete!(ctx.states, code)
+        delete!(ctx.code_verifiers, code)
+    end
     return parse_token_response(tok_res)
 end
 

--- a/src/OpenIDConnect.jl
+++ b/src/OpenIDConnect.jl
@@ -5,7 +5,7 @@ using JSON
 using MbedTLS
 using Base64
 using Random
-using Random.SHA 
+using SHA 
 using JWTs
 
 const DEFAULT_SCOPES = ["openid", "profile", "email"]


### PR DESCRIPTION
This PR fixes #12 by adding a keyword `pkce` to `flow_request_authorization_code()

### Usage
Call `flow_request_authorization_code(ctx; pkce = true)`

### Internal Flow
- `OIDCCtx` now contains a field `code_verifiers` to hold the verifiers that are generated during the code_challenge.
- `flow_request_authorization_code(ctx; pkce = true)` generates a pair of `code_challenge` and `code_verifier`and stores the latter in `ctx.code_verifiers[state]`.
- `flow_get_authorization_code(ctx, query)` retrieves the code together with the state and checks whether a verifier is stored under the state. If so it appends the verifier to the code with a leading space character and deletes it from `code_verifiers` (This is safe as the space character is not allowed as part of the code.)
- `flow_get_token(ctx, code)` checks whether `code` contains an appended verifier, if so it sends it together with the token request.
- The `purge_states!()` method has been adapted to also purge the verifiers. (And it has been renamed due to inconsistency with and without exclamation mark.)

### Miscellaneous
- `Manifest.toml` has been added to `.gitignore`
- Github actions have been updated
- bumped JWTs' compat to include v0.3

EDIT: adapted to the changed verfier handling