### PR TITLE
Support JWTs 1.0 (keep 0.3 compatibility)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "195a77af-17c0-520f-ac58-3336c7ea8576"
 keywords = ["openidconnect", "openid-connect", "openid", "openidc", "julia", "identity"]
 license = "MIT"
 desc = "OpenID Connect for Julia"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
 
 [deps]
@@ -18,7 +18,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 [compat]
 HTTP = "2.1.1"
 JSON = "0.21, 1"
-JWTs = "0.1, 0.2, 0.3"
+JWTs = "0.1, 0.2, 0.3, 1"
 Reseau = "1.2.1"
 SHA = "<0.0.1, 0.7, 1"
 julia = "1.10"

--- a/src/OpenIDConnect.jl
+++ b/src/OpenIDConnect.jl
@@ -5,7 +5,10 @@ using JSON
 using Base64
 using Random
 using SHA
-using JWTs
+# Import names explicitly rather than `using JWTs`: JWTs 1.0 exports nothing
+# (names are `public`, not exported). A selective import resolves the bindings
+# directly, so this works unchanged on JWTs 0.3 and 1.0 alike.
+using JWTs: JWKSet, JWT, JWK, issigned, claims, refresh!, validate!
 
 # Import Reseau.TLS for HTTP v2 custom certificate support
 import Reseau


### PR DESCRIPTION
## What

Adds support for **JWTs 1.0** while keeping backward compatibility with 0.3.

## Why

JWTs 1.0 intentionally exports no names — the public API is declared with `public` instead of `export`. As a result, `using JWTs` no longer brings `JWKSet`, `JWT`, `JWK`, `issigned`, `claims`, `refresh!`, `validate!` into scope, and OpenIDConnect fails to load against JWTs 1.0.

## Change

- Replace `using JWTs` with a selective `using JWTs: JWKSet, JWT, JWK, issigned, claims, refresh!, validate!`. A selective import resolves the bindings directly regardless of export/public status, so it works unchanged on **both** 0.3 and 1.0.
- All names used here exist with compatible signatures in both versions — no logic changes required.
- Widen `[compat]` JWTs to `"0.1, 0.2, 0.3, 1"`.
- Bump version `0.2.0` → `0.2.1`.

## Testing

Full test suite passes against **both** JWTs 0.3.2 and 1.0.0 (34/34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)